### PR TITLE
Allow annotations in check_source

### DIFF
--- a/tmc/utils.py
+++ b/tmc/utils.py
@@ -104,24 +104,25 @@ def check_source(module):
         source = module.__file__
     except Exception:
         raise Exception('Varmista, että koodin suoritus onnistuu')
-    allowed = []
-    allowed.append("import ")
-    allowed.append("from ")
-    allowed.append("def ")
-    allowed.append("class ")
-    allowed.append(" ")
-    allowed.append("\t")
-    allowed.append("#")
-    allowed.append("if __name__")
+    allowed = [
+        "import ",
+        "from ",
+        "def ",
+        "class ",
+        " ",
+        "\t",
+        "#",
+        "if __name__",
+        "@",
+    ]
     with open(source) as file:
         for line in file.readlines():
             if line.strip() == "":
                 continue
-            ok = False
             for prefix in allowed:
                 if line.startswith(prefix):
-                    ok = True
-            if not ok:
+                    break
+            else:
                 return (False, line)
         return (True, "")
 


### PR DESCRIPTION
Allows annotations in `check_source` s.t. the following is fine:

```python
from functools import total_ordering

@total_ordering
class Raha:
    ...
```

Also some slight cleanup of the code (removed redundant `list.append`s, `for..else` instead of redundant variable).